### PR TITLE
Implement electricity purchase backend via Redbiller

### DIFF
--- a/app/Http/Controllers/Bills/ElectricityController.php
+++ b/app/Http/Controllers/Bills/ElectricityController.php
@@ -20,7 +20,24 @@ class ElectricityController extends Controller
     public function purchase(ElectricityPurchaseRequest $r)
     {
         $res = $this->svc->purchase($r->validated());
-        return response()->json($res, $res['response']['ok'] ? 200 : 422);
+        $provider = $res['response'] ?? [];
+        $transaction = $res['transaction'] ?? [];
+
+        return response()->json([
+            'reference'      => $res['reference'],
+            'status'         => $transaction['status'] ?? null,
+            'customer_name'  => $transaction['customer_name'] ?? null,
+            'amount'         => $transaction['amount'] ?? null,
+            'amount_paid'    => $transaction['amount_paid'] ?? null,
+            'fee'            => $transaction['fee'] ?? null,
+            'cost'           => $transaction['cost'] ?? null,
+            'currency'       => $transaction['currency'] ?? null,
+            'tokens'         => $transaction['tokens'] ?? [],
+            'provider'       => [
+                'ok'     => $provider['ok'] ?? false,
+                'status' => $provider['status'] ?? null,
+            ],
+        ], ($provider['ok'] ?? false) ? 200 : 422);
     }
 
     public function status(string $reference)

--- a/app/Http/Requests/ElectricityPurchaseRequest.php
+++ b/app/Http/Requests/ElectricityPurchaseRequest.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Requests;
 
+use App\Support\ElectricityDiscoMap;
 use Illuminate\Foundation\Http\FormRequest;
 
 class ElectricityPurchaseRequest extends FormRequest
@@ -11,7 +12,21 @@ class ElectricityPurchaseRequest extends FormRequest
      */
     public function authorize(): bool
     {
-        return false;
+        return (bool) $this->user();
+    }
+
+    public function prepareForValidation(): void
+    {
+        $amount = preg_replace('/[^0-9]/', '', (string) $this->input('amount'));
+
+        $this->merge([
+            'disco'        => ElectricityDiscoMap::normalize((string) $this->input('disco')),
+            'meter_no'     => preg_replace('/\s+/', '', (string) $this->input('meter_no')),
+            'type'         => strtolower((string) $this->input('type')),
+            'amount'       => $amount !== '' ? (int) $amount : $amount,
+            'callback_url' => $this->input('callback_url') ? trim((string) $this->input('callback_url')) : null,
+            'reference'    => $this->input('reference') ? trim((string) $this->input('reference')) : null,
+        ]);
     }
 
     /**

--- a/app/Http/Requests/ElectricityValidateRequest.php
+++ b/app/Http/Requests/ElectricityValidateRequest.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Requests;
 
+use App\Support\ElectricityDiscoMap;
 use Illuminate\Foundation\Http\FormRequest;
 
 class ElectricityValidateRequest extends FormRequest
@@ -11,7 +12,16 @@ class ElectricityValidateRequest extends FormRequest
      */
     public function authorize(): bool
     {
-        return false;
+        return (bool) $this->user();
+    }
+
+    public function prepareForValidation(): void
+    {
+        $this->merge([
+            'disco'    => ElectricityDiscoMap::normalize((string) $this->input('disco')),
+            'meter_no' => preg_replace('/\s+/', '', (string) $this->input('meter_no')),
+            'type'     => strtolower((string) $this->input('type')),
+        ]);
     }
 
     /**
@@ -22,7 +32,7 @@ class ElectricityValidateRequest extends FormRequest
     public function rules(): array {
         return [
             'disco'      => 'required|string|max:50',     // e.g., IBEDC, EKO, AEDC...
-            'meter_no'   => 'required|string|max:32',
+            'meter_no'   => 'required|string|min:5|max:32',
             'type'       => 'required|in:prepaid,postpaid',
         ];
     }

--- a/app/Models/BillTransaction.php
+++ b/app/Models/BillTransaction.php
@@ -15,9 +15,9 @@ class BillTransaction extends Model
 
     protected $fillable = [
         'reference','service','product','network','phone','account','plan_id','ported',
-        'amount','amount_paid','amount_discount','provider','provider_txn_id',
-        'callback_url','status','paid_at','failed_at',
-        'request_payload','provider_response','webhook_payload',
+        'customer_name','amount','amount_paid','amount_discount','fee','cost','currency',
+        'provider','provider_txn_id','callback_url','status','paid_at','failed_at',
+        'request_payload','provider_response','webhook_payload','meta',
     ];
 
     protected $casts = [
@@ -25,11 +25,14 @@ class BillTransaction extends Model
         'amount'            => 'integer',
         'amount_paid'       => 'integer',
         'amount_discount'   => 'integer',
+        'fee'               => 'integer',
+        'cost'              => 'integer',
         'paid_at'           => 'datetime',
         'failed_at'         => 'datetime',
         'request_payload'   => 'array',
         'provider_response' => 'array',
         'webhook_payload'   => 'array',
+        'meta'              => 'array',
     ];
 
     public function electricityTokens() { return $this->hasMany(\App\Models\ElectricityToken::class); }

--- a/app/Services/Redbiller/ElectricityService.php
+++ b/app/Services/Redbiller/ElectricityService.php
@@ -29,16 +29,27 @@ class ElectricityService
         $ref = $input['reference'] ?? Str::ulid()->toBase32();
 
         $payload = [
-            'disco'        => $input['disco'],
-            'meter_no'     => $input['meter_no'],
-            'type'         => $input['type'],
-            'amount'       => (int) $input['amount'],
-            'reference'    => $ref,
+            'disco'     => $input['disco'],
+            'meter_no'  => $input['meter_no'],
+            'type'      => $input['type'],
+            'amount'    => (int) $input['amount'],
+            'reference' => $ref,
         ];
-        if (!empty($input['callback_url'])) $payload['callback_url'] = $input['callback_url'];
+        if (!empty($input['callback_url'])) {
+            $payload['callback_url'] = $input['callback_url'];
+        }
 
         $path = $this->client->path('electricity', 'purchase_create');
         $res  = $this->client->post($path, $payload);
+
+        $body = $res['json'] ?? [];
+        if (!is_array($body) || empty($body)) {
+            $body = ['raw' => $res['body']];
+        }
+
+        $status = $res['ok']
+            ? strtoupper($body['status'] ?? BillTransaction::S_PENDING)
+            : BillTransaction::S_FAILED;
 
         $tx = BillTransaction::create([
             'reference'         => $ref,
@@ -46,29 +57,66 @@ class ElectricityService
             'product'           => $input['disco'],
             'account'           => $input['meter_no'],
             'amount'            => (int) $input['amount'],
-            'currency'          => 'NGN',
+            'amount_paid'       => (int) ($body['amount_paid'] ?? 0),
+            'fee'               => (int) ($body['fee'] ?? ($body['charges'] ?? 0)),
+            'cost'              => (int) ($body['amount_debited'] ?? ($body['amount'] ?? 0)),
+            'currency'          => strtoupper($body['currency'] ?? 'NGN'),
             'provider'          => 'redbiller',
-            'status'            => $res['ok'] ? strtoupper($res['json']['status'] ?? 'PENDING') : 'FAILED',
+            'provider_txn_id'   => $body['id'] ?? null,
+            'callback_url'      => $input['callback_url'] ?? null,
+            'customer_name'     => $body['customer_name'] ?? null,
+            'status'            => $status,
             'request_payload'   => $payload,
-            'provider_response' => $res['json'] ?? ['raw' => $res['body']],
+            'provider_response' => $body,
             'meta'              => ['type' => $input['type']],
         ]);
 
+        if ($status === BillTransaction::S_SUCCESS) {
+            $tx->markSuccess($body);
+        } elseif ($status === BillTransaction::S_FAILED) {
+            $tx->markFailed($body);
+        }
+
         // If response already includes tokens, stash them
-        $tokens = $res['json']['tokens'] ?? $res['json']['data']['tokens'] ?? null;
+        $tokens = $body['tokens'] ?? ($body['data']['tokens'] ?? null);
         if (is_array($tokens)) {
             foreach ($tokens as $tk) {
-                ElectricityToken::create([
+                $tokenValue = $tk['token'] ?? ($tk['pin'] ?? null);
+                if (!$tokenValue) {
+                    continue;
+                }
+
+                ElectricityToken::firstOrCreate([
                     'bill_transaction_id' => $tx->id,
-                    'token'     => $tk['token'] ?? ($tk['pin'] ?? ''),
-                    'units'     => isset($tk['units']) ? (int)$tk['units'] : null,
+                    'token'               => $tokenValue,
+                ], [
+                    'units'       => isset($tk['units']) ? (int) $tk['units'] : null,
                     'tariff_code' => $tk['tariff'] ?? null,
-                    'raw'       => $tk,
+                    'raw'         => $tk,
                 ]);
             }
         }
 
-        return ['reference' => $ref, 'response' => $res];
+        $tx->load('electricityTokens');
+
+        return [
+            'reference'    => $ref,
+            'transaction'  => [
+                'status'        => $tx->status,
+                'customer_name' => $tx->customer_name,
+                'amount'        => $tx->amount,
+                'amount_paid'   => $tx->amount_paid,
+                'fee'           => $tx->fee,
+                'cost'          => $tx->cost,
+                'currency'      => $tx->currency,
+                'tokens'        => $tx->electricityTokens->map(fn ($token) => [
+                    'token'       => $token->token,
+                    'units'       => $token->units,
+                    'tariff_code' => $token->tariff_code,
+                ])->all(),
+            ],
+            'response'     => $res,
+        ];
     }
 
     /** Poll status; update transaction; capture tokens if they arrive late */
@@ -79,37 +127,45 @@ class ElectricityService
 
         $tx = BillTransaction::where('reference', $reference)->first();
         if ($tx && $res['ok']) {
-            $status = strtoupper($res['json']['status'] ?? $tx->status);
+            $body = $res['json'] ?? [];
+            $status = strtoupper($body['status'] ?? $tx->status);
             $tx->update([
                 'status'            => $status,
-                'customer_name'     => $res['json']['customer_name'] ?? $tx->customer_name,
-                'amount_paid'       => (int) ($res['json']['amount_paid'] ?? $tx->amount_paid),
-                'cost'              => (int) ($res['json']['amount_debited'] ?? $tx->cost),
-                'provider_txn_id'   => $res['json']['id'] ?? $tx->provider_txn_id,
-                'provider_response' => $res['json'],
+                'customer_name'     => $body['customer_name'] ?? $tx->customer_name,
+                'amount_paid'       => (int) ($body['amount_paid'] ?? $tx->amount_paid),
+                'cost'              => (int) ($body['amount_debited'] ?? $tx->cost),
+                'fee'               => (int) ($body['fee'] ?? $tx->fee),
+                'currency'          => strtoupper($body['currency'] ?? $tx->currency),
+                'provider_txn_id'   => $body['id'] ?? $tx->provider_txn_id,
+                'provider_response' => $body ?: ['raw' => $res['body']],
             ]);
 
             // Late tokens?
-            $tokens = $res['json']['tokens'] ?? $res['json']['data']['tokens'] ?? null;
+            $tokens = $body['tokens'] ?? ($body['data']['tokens'] ?? null);
             if (is_array($tokens)) {
                 foreach ($tokens as $tk) {
-                    $exists = ElectricityToken::where('bill_transaction_id', $tx->id)
-                        ->where('token', $tk['token'] ?? ($tk['pin'] ?? ''))
-                        ->exists();
-                    if (!$exists) {
-                        ElectricityToken::create([
-                            'bill_transaction_id' => $tx->id,
-                            'token'     => $tk['token'] ?? ($tk['pin'] ?? ''),
-                            'units'     => isset($tk['units']) ? (int)$tk['units'] : null,
-                            'tariff_code' => $tk['tariff'] ?? null,
-                            'raw'       => $tk,
-                        ]);
+                    $tokenValue = $tk['token'] ?? ($tk['pin'] ?? null);
+                    if (!$tokenValue) {
+                        continue;
                     }
+
+                    ElectricityToken::firstOrCreate([
+                        'bill_transaction_id' => $tx->id,
+                        'token'               => $tokenValue,
+                    ], [
+                        'units'       => isset($tk['units']) ? (int) $tk['units'] : null,
+                        'tariff_code' => $tk['tariff'] ?? null,
+                        'raw'         => $tk,
+                    ]);
                 }
             }
 
-            if ($status === 'SUCCESS' && !$tx->paid_at) $tx->markSuccess($res['json']);
-            if ($status === 'FAILED'  && !$tx->failed_at) $tx->markFailed($res['json']);
+            if ($status === BillTransaction::S_SUCCESS && !$tx->paid_at) {
+                $tx->markSuccess($body ?: []);
+            }
+            if ($status === BillTransaction::S_FAILED  && !$tx->failed_at) {
+                $tx->markFailed($body ?: []);
+            }
         }
 
         return $res;

--- a/app/Support/ElectricityDiscoMap.php
+++ b/app/Support/ElectricityDiscoMap.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Support;
+
+final class ElectricityDiscoMap
+{
+    /**
+     * Map a variety of front-end identifiers to the provider disco codes expected by Redbiller.
+     */
+    private const MAP = [
+        'abuja-electricity' => 'AEDC',
+        'abuja'             => 'AEDC',
+        'aedc'              => 'AEDC',
+        'ikeja-electricity' => 'IKEDC',
+        'ikeja'             => 'IKEDC',
+        'ikedc'             => 'IKEDC',
+        'eko-electricity'   => 'EKEDC',
+        'eko'               => 'EKEDC',
+        'ekedc'             => 'EKEDC',
+        'ibadan-electricity'=> 'IBEDC',
+        'ibadan'            => 'IBEDC',
+        'ibedc'             => 'IBEDC',
+        'benin-electricity' => 'BEDC',
+        'benin'             => 'BEDC',
+        'bedc'              => 'BEDC',
+        'enugu-electricity' => 'EEDC',
+        'enugu'             => 'EEDC',
+        'eedc'              => 'EEDC',
+        'jos-electricity'   => 'JEDC',
+        'jos'               => 'JEDC',
+        'jedc'              => 'JEDC',
+        'kano-electricity'  => 'KEDCO',
+        'kano'              => 'KEDCO',
+        'kedco'             => 'KEDCO',
+        'kaduna-electricity'=> 'KAEDCO',
+        'kaduna'            => 'KAEDCO',
+        'kaedco'            => 'KAEDCO',
+        'port-harcourt-electricity' => 'PHED',
+        'portharcourt-electricity'  => 'PHED',
+        'port-harcourt'             => 'PHED',
+        'portharcourt'              => 'PHED',
+        'phed'                      => 'PHED',
+    ];
+
+    public static function normalize(string $value): string
+    {
+        $trimmed = trim($value);
+        if ($trimmed === '') {
+            return $trimmed;
+        }
+
+        $slug = strtolower(str_replace(['_', ' '], '-', $trimmed));
+        // Accept ids that carry the meter type suffix, e.g. `abuja-electricity-prepaid`.
+        $slug = preg_replace('/-(prepaid|postpaid)$/', '', $slug);
+        $slug = $slug ?? '';
+
+        return self::MAP[$slug] ?? strtoupper($trimmed);
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -2,6 +2,7 @@
 
 use App\Http\Controllers\Api\AuthController;
 use App\Http\Controllers\Bills\AirtimeController;
+use App\Http\Controllers\Bills\ElectricityController;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 
@@ -11,6 +12,9 @@ Route::get('/user', function (Request $request) {
 
 Route::middleware('auth:sanctum')->group(function () {
     Route::post('/bills/airtime', [AirtimeController::class, 'purchase'])->name('api.bills.airtime');
+    Route::post('/bills/electricity/validate', [ElectricityController::class, 'validateCustomer']);
+    Route::post('/bills/electricity', [ElectricityController::class, 'purchase']);
+    Route::get('/bills/electricity/{reference}/status', [ElectricityController::class, 'status']);
 });
 
 Route::post('/auth/login',  [AuthController::class, 'login']);
@@ -20,4 +24,7 @@ Route::post('/auth/logout', [AuthController::class, 'logout'])->middleware('auth
 Route::middleware('auth:sanctum')->group(function () {
     Route::get('/me', fn (Request $r) => $r->user());
     Route::post('/bills/airtime', [AirtimeController::class,'purchase']);
+    Route::post('/bills/electricity/validate', [ElectricityController::class, 'validateCustomer']);
+    Route::post('/bills/electricity', [ElectricityController::class, 'purchase']);
+    Route::get('/bills/electricity/{reference}/status', [ElectricityController::class, 'status']);
 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,6 +2,7 @@
 
 use App\Http\Controllers\Bills\AirtimeController;
 use App\Http\Controllers\Bills\MobileDataController;
+use App\Http\Controllers\Bills\ElectricityController;
 use App\Http\Controllers\BillsController;
 use App\Http\Controllers\DashboardController;
 use App\Http\Controllers\Settings\ProfileController;
@@ -52,6 +53,9 @@ Route::middleware('auth')->group(function () {
     Route::post('/bills/airtime', [AirtimeController::class,'purchase']);
     Route::post('/bills/data', [MobileDataController::class,'purchase']);
     Route::get('/bills/data/plans', [MobileDataController::class, 'getPlans']); // ?network=mtn
+    Route::post('/bills/electricity/validate', [ElectricityController::class, 'validateCustomer']);
+    Route::post('/bills/electricity', [ElectricityController::class, 'purchase']);
+    Route::get('/bills/electricity/{reference}/status', [ElectricityController::class, 'status']);
 });
 
 require __DIR__.'/auth.php';

--- a/tests/Feature/Services/Redbiller/ElectricityServiceTest.php
+++ b/tests/Feature/Services/Redbiller/ElectricityServiceTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Tests\Feature\Services\Redbiller;
+
+use App\Models\BillTransaction;
+use App\Services\Redbiller\ElectricityService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+class ElectricityServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_purchase_persists_transaction_and_tokens()
+    {
+        Http::fake([
+            '*' => Http::response([
+                'status'         => 'SUCCESS',
+                'id'             => 'RB123456',
+                'customer_name'  => 'Jane Doe',
+                'amount_debited' => 5200,
+                'amount_paid'    => 5000,
+                'fee'            => 200,
+                'currency'       => 'NGN',
+                'tokens'         => [
+                    [
+                        'token'  => '123456789012',
+                        'units'  => 43,
+                        'tariff' => 'A1',
+                    ],
+                ],
+            ], 200),
+        ]);
+
+        $service = app(ElectricityService::class);
+
+        $result = $service->purchase([
+            'disco'    => 'IKEDC',
+            'meter_no' => '12345678901',
+            'type'     => 'prepaid',
+            'amount'   => 5000,
+        ]);
+
+        $this->assertTrue($result['response']['ok']);
+        $this->assertEquals('SUCCESS', $result['transaction']['status']);
+        $this->assertSame('Jane Doe', $result['transaction']['customer_name']);
+        $this->assertSame('NGN', $result['transaction']['currency']);
+        $this->assertCount(1, $result['transaction']['tokens']);
+
+        $tx = BillTransaction::where('reference', $result['reference'])->first();
+        $this->assertNotNull($tx);
+        $this->assertEquals(BillTransaction::S_SUCCESS, $tx->status);
+        $this->assertEquals('electricity', $tx->service);
+        $this->assertEquals('IKEDC', $tx->product);
+        $this->assertEquals('12345678901', $tx->account);
+        $this->assertEquals(5000, $tx->amount);
+        $this->assertEquals(5200, $tx->cost);
+        $this->assertEquals(200, $tx->fee);
+        $this->assertEquals('Jane Doe', $tx->customer_name);
+        $this->assertNotNull($tx->paid_at);
+        $this->assertCount(1, $tx->electricityTokens);
+        $this->assertEquals('123456789012', $tx->electricityTokens->first()->token);
+    }
+}


### PR DESCRIPTION
## Summary
- normalise electricity disco identifiers and authorise the new validation and purchase form requests
- persist Redbiller purchase responses including tokens, monetary fields, and expose safe payloads from the electricity controller
- register web/API electricity routes and add a regression test covering token persistence in the Redbiller electricity service

## Testing
- Unable to run `php artisan test` because installing Composer dependencies fails in the execution environment (GitHub connectivity returns HTTP 403).


------
https://chatgpt.com/codex/tasks/task_e_68db9450711c832a8d997b6f8490e0d5